### PR TITLE
fix requiring of core_ext when time-warp gem is already loaded

### DIFF
--- a/lib/ruby-mass.rb
+++ b/lib/ruby-mass.rb
@@ -1,3 +1,6 @@
-require "core_ext"
-require "mass"
-require "ruby-mass/version"
+# require 'core_ext' will fail if the time-warp gem is already loaded so we need
+# to require the fully qualified path name instead
+
+['core_ext', 'mass', 'ruby-mass/version'].each do |file|
+  require File.join File.dirname(__FILE__), file
+end


### PR DESCRIPTION
(this is probably the root cause of #3)

in `ruby-mass.rb` this line:

```
require 'core_ext'
```

will fail to load `ruby-mass`'s `core_ext.rb` if the `time-warp` gem was loaded first:

```
2.1.0 :001 > require 'ruby-mass'
 => true
2.1.0 :002 > $".select{|a| a.match /\/lib\/core_ext\.rb/ }
 => ["/Users/schatzj/.rvm/gems/ruby-2.1.0@rails3-ruby21/gems/ruby-mass-0.1.3/lib/core_ext.rb"]
```

vs

```
2.1.0 :001 > require 'time-warp'
 => true
2.1.0 :002 > require 'ruby-mass'
 => true
2.1.0 :003 > $".select{|a| a.match /\/lib\/core_ext\.rb/ }
 => ["/Users/schatzj/.rvm/gems/ruby-2.1.0@rails3-ruby21/gems/time-warp-1.0.13/lib/core_ext.rb"]
```

this patch changes the requires in `ruby-mass.rb` to use fully qualified pathnames to work around this:

```
2.1.0 :001 > require 'time-warp'
 => true
2.1.0 :002 > require 'ruby-mass'
 => true
2.1.0 :003 > $".select{|a| a.match /\/lib\/core_ext\.rb/ }
 => ["/Users/schatzj/.rvm/gems/ruby-2.1.0@rails3-ruby21/gems/time-warp-1.0.13/lib/core_ext.rb", "/Users/schatzj/git/ruby-mass/lib/core_ext.rb"]
```
